### PR TITLE
Log warning when animating shader keywords

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Service/ActionClipService.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Service/ActionClipService.cs
@@ -368,6 +368,25 @@ namespace VF.Service {
                 .Select(t => t.Value)
                 .DefaultIfEmpty(ShaderUtil.ShaderPropertyType.Float)
                 .First();
+
+            // this is a list of all distinct shader keywords for the materials
+            // and shaders currently on the renderers
+            var keywords = renderers
+                //Get all of the materials
+                .SelectMany( x => x.materials )
+                .Select( x => x.shader )
+                .SelectMany( x => x.keywordSpace.keywordNames )
+                .Distinct()
+                .ToList();
+
+            var toFind = propName.ToUpper() + "_ON";
+            var propIsKeyword = keywords.Contains(toFind);
+
+            if (propIsKeyword)
+            {
+                Debug.LogWarning($"Property \"{propName}\" is a shader keyword and may not animate correctly");
+            }
+
             return (renderers, type);
         }
 


### PR DESCRIPTION
As shader keywords can't be animated like a float can log a warning when attempting to do so.